### PR TITLE
Remove duplicite definition and add check for pip

### DIFF
--- a/thoth/build_analysers/analysis.py
+++ b/thoth/build_analysers/analysis.py
@@ -176,7 +176,7 @@ def build_breaker_analyze(log: str, *, colorize: bool = True):
 
     scores, candidate_indices = build_breaker_predict(log_messages, patterns, which == "pip")
 
-    df_log = pd.DataFrame(zip(log_messages, scores), columns=["msg", "score"])
+    df_log = pd.DataFrame(list(zip(log_messages, scores)), columns=["msg", "score"])
     df_log["pattern"] = [patterns[int(i)] if i is not None else None for i in candidate_indices]
 
     threshold_e = THRESHOLDS["ERROR"]

--- a/thoth/build_analysers/analysis.py
+++ b/thoth/build_analysers/analysis.py
@@ -50,7 +50,7 @@ REPORT_TEMPLATE = string.Template(
     """
 Build breaker:
 
-$info     
+$info
 
 Probable reason:
 
@@ -62,7 +62,7 @@ Probable reason:
 # TODO: Implement binary classifier to distinguish pip / pipenv logs
 def retrieve_build_log_patterns(log_messages: List[str]) -> Tuple[str, pd.DataFrame]:
     """Retrieve build log patterns based on the given log file.
-    
+
     This function detects whether the log file has been produced
     by 'pip' or 'pipenv' and retrieves appropriate resources.
     """
@@ -130,15 +130,15 @@ def build_breaker_predict(
     log_messages: Iterable[str], patterns: Iterable[str], reverse_scores: bool = False
 ) -> np.ndarray:
     """Predict scores and candidate pattern indices for each log message in `log`.
-    
+
     The method compares each message in `log` with a candidate pattern in `patterns`
     and outputs similarity score based on a BoW approach penalized by the length of
     the log message.
-    
+
     :param logs: Iterable[str], An iterable of log messages
     :param patterns: Iterable[str], patterns to compare to log messages
     :returns: np.ndarray of shape (2, n), n is length of logs
-    
+
         dimensions represent message similarity score and candidate pattern index respectively
     """
     print(f"Length of the log file: {len(log_messages)}")
@@ -214,7 +214,7 @@ def build_breaker_identify(dep_table: pd.DataFrame, error_messages: List[str]) -
 
 def simple_bow_similarity(matcher: str, matchee: str) -> Tuple[float, List[str]]:
     """Compare two sentences and count number of common words.
-    
+
     :returns: float, score representing sentence similarity
     """
     x = set(matchee.strip().lower().split())
@@ -233,11 +233,11 @@ def simple_bow_similarity(matcher: str, matchee: str) -> Tuple[float, List[str]]
 
 def simple_bow_similarity_with_replacement(matcher: str, matchee: str, reformat=False) -> Tuple[float, List[str]]:
     """Compare two strings while respecting matcher string formatting syntax.
-    
+
     This function checks for string formatted syntax in the `matcher`
     pattern and replaces it with regexp based syntax. Then size of the span
     is computed and transformed into similarity score.
-    
+
     :returns: float, score representing sentence similarity
     """
     score = 0

--- a/thoth/build_analysers/parsing/handlers/pip3.py
+++ b/thoth/build_analysers/parsing/handlers/pip3.py
@@ -207,7 +207,7 @@ class PIP3(HandlerBase):
                 continue
 
             if line.startswith("Successfully installed "):
-                packages = line[len("Successfully installed ") :].split(" ")
+                packages = line[len("Successfully installed "):].split(" ")
                 for package in packages:
                     package_name, version = package.rsplit("-", maxsplit=1)
                     self._check_entry(result, package_name, version)

--- a/thoth/build_analysers/preprocessing.py
+++ b/thoth/build_analysers/preprocessing.py
@@ -46,7 +46,7 @@ tostring = _tostring_factory()
 
 def build_log_prepare(log: str) -> List[str]:
     """Process raw build log by lines and output list of log messages.
-    
+
     :returns: List[str], list of log messages
     """
     log_messages = log.splitlines()
@@ -117,7 +117,7 @@ def ast_search_pipenv(entrypoint: str):
 
 def ast_to_pattern_dataframe(elements: list, patterns: List[str]) -> pd.DataFrame:
     """Convert AST matches into a pattern dataframe.
-    
+
     :param elements: list of AST elements corresponding to the patterns
     """
     if not len(elements) == len(patterns):
@@ -219,7 +219,6 @@ PEP_461_FORMAT_CODES = {"c", "b", "a", "r", "s", "d", "i", "o", "u", "x", "X", "
 
 def reformat(string: str) -> str:
     """Reformat format codes by PEP 461 and PEP 3101 to formatting style defined by `parse` library."""
-
     def _reformat(rest):
         span = re.search(r"(?:(?<=\s)|(?<=\W)|(?<=^))(%\w)|(\{.*?\})(?=\s|\W|$)", rest)
         if span is not None:
@@ -229,7 +228,7 @@ def reformat(string: str) -> str:
                 formatted = rest[: span.start()] + "{}"
 
                 yield formatted
-                yield from _reformat(rest[span.end() :])
+                yield from _reformat(rest[span.end():])
         else:
             yield rest
 


### PR DESCRIPTION
Depends-On: https://github.com/thoth-station/zuul-config/pull/53

`build_breaker_identify` had multiple definitions in the analysis module

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   thoth/build_analysers/analysis.py