### PR TITLE
 Split `report` and `format_report` functions and output candidates 

### DIFF
--- a/thoth/build_analysers/analysis.py
+++ b/thoth/build_analysers/analysis.py
@@ -54,7 +54,11 @@ $info
 
 Probable reason:
 
-    $ln: $reason
+    $reason
+
+Candidates:
+
+$candidates
 """
 )
 
@@ -103,32 +107,69 @@ def retrieve_build_log_patterns(log_messages: List[str]) -> Tuple[str, pd.DataFr
     return ("pip", patterns_pip) if score["pip"] >= score["pipenv"] else ("pipenv", patterns_pipenv)
 
 
-def build_breaker_report(log: str, *, colorize: bool = False, indentation_level: int = 4) -> str:
-    """Analyze raw build log and produce a report."""
-    df_log = build_breaker_analyze(log)
-    dep_table = build_log_to_dependency_table(log)
+def build_breaker_report(log: Union[str, pd.DataFrame], *, top: int = 5, colorize: bool = False) -> dict:
+    """Analyze raw build log and produce a report.
 
-    report = "No build breaker identified."
+    :param log: Union[str, pd.DataFrame], raw build log to be analyzed or result of `build_log_analyze`
+    :param top: int, maximum number of candidates to report
+    :param colorize: bool, whether to map scores to colors (only valid if `log` is instance of str)
+    """
+    df_log = log
+    if isinstance(log, str):
+        df_log = build_breaker_analyze(log, colorize=colorize)
 
-    if len(dep_table) >= 1:
-        errors = df_log.query("label == 'ERROR' & msg.str.contains('|'.join(@dep_table.target))", engine="python")
-        build_breaker = build_breaker_identify(dep_table, errors.msg)
+    info = pd.DataFrame()
+    reason = ""
+    candidates = []
 
-        if build_breaker:
-            build_breaker_info = dep_table.query(f"target == '{build_breaker}'")
+    errors = df_log.query("label == 'ERROR'")
 
-            line_no, reason = next(
-                df_log.query("msg.str.contains(@build_breaker)", engine="python").msg[::-1].iteritems()
-            )
+    if len(errors) >= 1:
 
-            build_breaker_info_str = json.dumps(
-                build_breaker_info.to_dict(orient="records")[0], indent=indentation_level, sort_keys=True
-            )
-            build_breaker_info_str = textwrap.indent(build_breaker_info_str, " " * indentation_level)
+        dep_table = build_log_to_dependency_table(log)
 
-            report = REPORT_TEMPLATE.safe_substitute(info=build_breaker_info_str, ln=line_no, reason=reason)
+        if len(dep_table) >= 1:
+            errors = errors.query("msg.str.contains('|'.join(@dep_table.target))", engine="python")
+            build_breaker = build_breaker_identify(dep_table, errors.msg)
 
-    return report
+            if build_breaker:
+                info = dep_table.query(f"target == '{build_breaker}'")
+
+                reason = next(
+                    errors.query("msg.str.contains(@build_breaker)", engine="python").msg[::-1].iteritems()
+                )
+            elif len(errors) >= 1:
+                reason = next(errors.sort_values("score").msg[::-1].iteritems())
+        else:
+            reason = next(errors.sort_values("score").msg[::-1].iteritems())
+
+        candidates = list(errors.sort_values("score").msg[::-1].iteritems())
+
+    return {"info": info, "reason": reason, "candidates": candidates}
+
+
+def build_breaker_format_report(report: dict, indentation_level: int = 4) -> str:
+    """Format the report produced by the `build_breaker_report` function into string."""
+    if not report["candidates"]:
+        return "No build breaker candidates identified."
+
+    records = report["info"].to_dict(orient="records")
+    build_breaker_info_str = json.dumps(
+        records, indent=indentation_level, sort_keys=True
+    )
+    build_breaker_info_str = textwrap.indent(build_breaker_info_str, " " * indentation_level)
+
+    def _format_reason(ln: str, reason: str):
+        return f"{ln}: {reason}"
+
+    build_breaker_candidates_str = json.dumps([_format_reason(*c) for c in report["candidates"]], indent=indentation_level, sort_keys=False)
+    build_breaker_candidates_str = textwrap.indent(build_breaker_candidates_str, " " * indentation_level)
+
+    return REPORT_TEMPLATE.safe_substitute(
+        info=build_breaker_info_str,
+        reason=_format_reason(*report["reason"]),
+        candidates=build_breaker_candidates_str,
+    )
 
 
 def build_breaker_predict(

--- a/thoth/build_analysers/analysis.py
+++ b/thoth/build_analysers/analysis.py
@@ -50,7 +50,7 @@ REPORT_TEMPLATE = string.Template(
     """
 Build breaker:
 
-$info
+$build_breaker
 
 Probable reason:
 
@@ -113,39 +113,60 @@ def build_breaker_report(log: Union[str, pd.DataFrame], *, top: int = 5, coloriz
     :param log: Union[str, pd.DataFrame], raw build log to be analyzed or result of `build_log_analyze`
     :param top: int, maximum number of candidates to report
     :param colorize: bool, whether to map scores to colors (only valid if `log` is instance of str)
+
+    :returns: dict of the following schema:
+        {
+            "build_breaker": {
+                "already_satisfied": bool,
+                "source": str,
+                "target": str,
+                "version_installed": str,
+                "version_specified": str
+            },
+            "reason": {
+                "ln": str,
+                "msg" : str
+            },
+            "candidates": List[dict#reason]
+        }
     """
     df_log = log
     if isinstance(log, str):
         df_log = build_breaker_analyze(log, colorize=colorize)
 
-    info = pd.DataFrame()
-    reason = ""
+    build_breaker_info = dict()
+    """Dictionary holding build breaker attributs."""
+    reason = dict()
+    """Probable reason of the failure."""
     candidates = []
+    """List of top *k* candidates to cause the build failure."""
 
     errors = df_log.query("label == 'ERROR'")
 
     if len(errors) >= 1:
-
         dep_table = build_log_to_dependency_table(log)
 
         if len(dep_table) >= 1:
             errors = errors.query("msg.str.contains('|'.join(@dep_table.target))", engine="python")
-            build_breaker = build_breaker_identify(dep_table, errors.msg)
+            build_breaker_package_name: str = build_breaker_identify(dep_table, errors.msg)
 
-            if build_breaker:
-                info = dep_table.query(f"target == '{build_breaker}'")
-
-                reason = next(
-                    errors.query("msg.str.contains(@build_breaker)", engine="python").msg[::-1].iteritems()
+            if build_breaker_package_name:
+                build_breaker_info, = dep_table.query(f"target == '{build_breaker_package_name}'").to_dict(
+                    orient="records"
                 )
+                reason = next(
+                    errors.query("msg.str.contains(@build_breaker_package_name)", engine="python").msg[::-1].iteritems()
+                )
+
             elif len(errors) >= 1:
                 reason = next(errors.sort_values("score").msg[::-1].iteritems())
+
         else:
             reason = next(errors.sort_values("score").msg[::-1].iteritems())
 
-        candidates = list(errors.sort_values("score").msg[::-1].iteritems())
+        candidates = list(map(lambda t: dict(zip(["ln", "msg"], t)), errors.sort_values("score").msg[::-1].iteritems()))
 
-    return {"info": info, "reason": reason, "candidates": candidates}
+    return {"build_breaker": build_breaker_info, "reason": dict(zip(["ln", "msg"], reason)), "candidates": candidates}
 
 
 def build_breaker_format_report(report: dict, indentation_level: int = 4) -> str:
@@ -153,21 +174,20 @@ def build_breaker_format_report(report: dict, indentation_level: int = 4) -> str
     if not report["candidates"]:
         return "No build breaker candidates identified."
 
-    records = report["info"].to_dict(orient="records")
-    build_breaker_info_str = json.dumps(
-        records, indent=indentation_level, sort_keys=True
-    )
+    build_breaker_info_str = json.dumps(report["build_breaker"], indent=indentation_level, sort_keys=True)
     build_breaker_info_str = textwrap.indent(build_breaker_info_str, " " * indentation_level)
 
     def _format_reason(ln: str, reason: str):
         return f"{ln}: {reason}"
 
-    build_breaker_candidates_str = json.dumps([_format_reason(*c) for c in report["candidates"]], indent=indentation_level, sort_keys=False)
+    build_breaker_candidates_str = json.dumps(
+        [_format_reason(*c.values()) for c in report["candidates"]], indent=indentation_level, sort_keys=False
+    )
     build_breaker_candidates_str = textwrap.indent(build_breaker_candidates_str, " " * indentation_level)
 
     return REPORT_TEMPLATE.safe_substitute(
-        info=build_breaker_info_str,
-        reason=_format_reason(*report["reason"]),
+        build_breaker=build_breaker_info_str,
+        reason=_format_reason(*report["reason"].values()),
         candidates=build_breaker_candidates_str,
     )
 


### PR DESCRIPTION
Description:
- `build_breaker_report` no longer returns a string, instead, it returns a
dict to be formated by the `build_breaker_format_report` in case a
formatted output is required
- the report now outputs also a list of candidates that were found,
order by the score
- annotate and refactor analysis module 

An example of a report:

PIP:

```json
Build breaker:

    {
        "already_satisfied": null,
        "source": "thoth-lab",
        "target": "certifi",
        "version_installed": null,
        "version_specified": ">=2017.4.17"
    }

Probable reason:

    76: Cannot uninstall 'certifi'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.

Candidates:

    [
        "76: Cannot uninstall 'certifi'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall."
    ]
```

PIPENV (The package parsing is yet to be implemented):

```json
Build breaker:

    {}

Probable reason:

    2374: There are incompatible versions in the resolved dependencies.

Candidates:

    [
        "2374: There are incompatible versions in the resolved dependencies.",
        "2373: Tried: 1.0, 1.0, 1.2.1, 1.2.1, 1.3.0, 1.3.0, 1.3.0, 1.3.1, 1.3.1, 1.3.1, 1.3.2, 1.3.2, 1.3.2, 1.3.3, 1.3.3, 1.3.3, 1.4.0, 1.4.0, 1.4.0, 1.4.1, 1.4.1, 1.4.1, 1.4.2, 1.4.2, 1.4.2, 1.4.3, 1.4.3, 1.4.3, 1.4.4, 1.4.4, 1.4.4, 1.4.5, 1.4.5, 1.4.5, 1.4.5, 1.4.7, 1.4.7, 1.4.7, 2.0.0, 2.0.0, 2.0.0, 2.0.1, 2.0.1, 2.0.1, 2.0.2, 2.0.2, 2.0.2, 2.0.3, 2.0.3, 2.0.3, 2.0.4, 2.0.4, 2.0.4, 2.0.5, 2.0.5, 2.0.5, 2.0.6, 2.0.6, 2.0.6, 2.0.7, 2.0.7, 2.0.7, 2.0.8, 2.0.8, 2.0.8, 2.0.9, 2.0.9, 2.0.9, 2.0.10, 2.0.10, 2.0.10, 2.1.0, 2.1.0, 2.1.0, 2.1.1, 2.1.1, 2.1.1, 2.1.2, 2.1.2, 2.1.2",
        "2372: Could not find a version that matches aenum==1.4.5,>=1.4.5,~=2.0.8",
        "2371: Hint: try $ pipenv lock --pre if it is a pre-release dependency.",
        "2370: Alternatively, you can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.",
        "2369: First try clearing your dependency cache with $ pipenv lock --clear, then try the original command again.",
        "2368: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.",
        "2367: There are incompatible versions in the resolved dependencies.",
        "2366: Tried: 1.0, 1.0, 1.2.1, 1.2.1, 1.3.0, 1.3.0, 1.3.0, 1.3.1, 1.3.1, 1.3.1, 1.3.2, 1.3.2, 1.3.2, 1.3.3, 1.3.3, 1.3.3, 1.4.0, 1.4.0, 1.4.0, 1.4.1, 1.4.1, 1.4.1, 1.4.2, 1.4.2, 1.4.2, 1.4.3, 1.4.3, 1.4.3, 1.4.4, 1.4.4, 1.4.4, 1.4.5, 1.4.5, 1.4.5, 1.4.5, 1.4.7, 1.4.7, 1.4.7, 2.0.0, 2.0.0, 2.0.0, 2.0.1, 2.0.1, 2.0.1, 2.0.2, 2.0.2, 2.0.2, 2.0.3, 2.0.3, 2.0.3, 2.0.4, 2.0.4, 2.0.4, 2.0.5, 2.0.5, 2.0.5, 2.0.6, 2.0.6, 2.0.6, 2.0.7, 2.0.7, 2.0.7, 2.0.8, 2.0.8, 2.0.8, 2.0.9, 2.0.9, 2.0.9, 2.0.10, 2.0.10, 2.0.10, 2.1.0, 2.1.0, 2.1.0, 2.1.1, 2.1.1, 2.1.1, 2.1.2, 2.1.2, 2.1.2",
        "2365: Could not find a version that matches aenum==1.4.5,>=1.4.5,~=2.0.8",
        "2364: Hint: try $ pipenv lock --pre if it is a pre-release dependency.",
        "2363: Alternatively, you can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.",
        "2362: First try clearing your dependency cache with $ pipenv lock --clear, then try the original command again.",
        "2361: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies."
    ]
```