### PR TITLE
Added required env vars and templates for the build analyser cli

### DIFF
--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: build-analyser-buildconfig
+  annotations:
+    description: >
+      This is Thoth Build Analyser BuildConfig, this template is meant to be used by Bots, but could also be
+      used by humans...
+    openshift.io/display-name: "Thoth: Build Analyser BuildConfig"
+    version: 0.4.1
+    tags: thoth,ai-stacks,build-analyser
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station
+    template.openshift.io/long-description: >
+      This is Thoth Build Analyser BuildConfig, this template is meant to be
+      used by Bots, but could also be used by humans...
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+  labels:
+    template: build-analyser-buildconfig
+    app: thoth
+    component: build-analyser
+
+parameters:
+  - description: Git repository for Thoth's Build Analyser
+    displayName: Thoth Build Analyser git repository
+    required: true
+    name: GITHUB_URL
+    value: "https://github.com/thoth-station/build-analysers"
+
+  - description: Git repository for Thoth's Build Analyser
+    displayName: Thoth Build Analyser git reference
+    required: true
+    name: GITHUB_REF
+    value: "master"
+
+  - description: Tag of the output ImageStream the resulting container image should go to
+    displayName: ImageStream Tag
+    required: true
+    name: IMAGE_STREAM_TAG
+    value: "latest"
+
+objects:
+  - apiVersion: v1
+    kind: BuildConfig
+    metadata:
+      labels:
+        app: thoth
+        component: build-analyser
+      name: build-analyser
+    spec:
+      resources:
+        limits:
+          cpu: 1
+          memory: 768Mi
+        requests:
+          cpu: 1
+          memory: 768Mi
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "build-analyser:${IMAGE_STREAM_TAG}"
+      runPolicy: Serial
+      source:
+        git:
+          uri: ${GITHUB_URL}
+          ref: ${GITHUB_REF}
+        type: Git
+      strategy:
+        type: Source
+        sourceStrategy:
+          from:
+            kind: ImageStreamTag
+            name: python-36-centos7:latest
+          env:
+            - name: ENABLE_PIPENV
+              value: "1"
+            - name: UPGRADE_PIP_TO_LATEST
+              value: ""
+            - name: APP_FILE
+              value: "thoth-build-analyser"
+      triggers:
+        - imageChange: {}
+          type: ImageChange

--- a/openshift/imageStream-template.yaml
+++ b/openshift/imageStream-template.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: build-analyser-imagestream
+  annotations:
+    description: >
+      This is Thoth Build Analyser ImageStream, this template is meant to be used by Bots, but could also
+      be used by humans
+    openshift.io/display-name: "Thoth: Build Analyser ImageStream"
+    version: 0.4.1
+    tags: thoth,ai-stacks,build-analyser
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station
+    template.openshift.io/long-description: >
+      This is Thoth Build Analyser ImageStream, this template is meant to be used by Bots, but could also
+      be used by humans...
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+  labels:
+    app: thoth
+    component: build-analyser
+
+objects:
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      labels:
+        app: thoth
+        component: build-analyser
+      name: build-analyser
+    spec:
+      name: latest
+      lookupPolicy:
+        local: true

--- a/openshift/job-build-analyse-template.yaml
+++ b/openshift/job-build-analyse-template.yaml
@@ -1,0 +1,150 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: build-analyse
+  annotations:
+    description: "Thoth: Build Log Analysis Analyse"
+    openshift.io/display-name: "Thoth: Build Log Analysis Analyse"
+    version: 0.1.0
+    tags: thoth,ai-stacks,build-analyser
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to run recommendation logic of Thoth to OpenShift.
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+  labels:
+    app: thoth
+    template: build-analyse
+    component: build-analyse
+
+parameters:
+  - name: IMAGE_STREAM_REGISTRY
+    description: Registry where the ImageStream is present.
+    displayName: ImageStream Registry
+    required: true
+    value: "docker-registry.default.svc:5000"
+
+  - name: IMAGE_STREAM_TAG
+    description: Tag of the ImageStream to be used.
+    displayName: ImageStream Tag
+    required: true
+    value: "latest"
+
+  - name: THOTH_BUILD_ANALYSER_LOG_PATH
+    description: Path for the build log read/write.
+    displayName: Log Path
+    required: false
+    value: "/opt/app-root/src/build.log"
+
+  - name: THOTH_BUILD_ANALYSER_OUTPUT_FORMAT
+    description: Required Output format.
+    displayName: ImageStream Tag
+    required: false
+    value: "json"
+
+  - name: IMAGE_STREAM_NAMESPACE
+    description: Project/Namespace to be used for deployment.
+    displayName: ImageStream Project
+    required: true
+
+  - name: THOTH_BUILD_ANALYSER_JOB_ID
+    description: A unique dentifier of build-analyser job.
+    displayName: Build Analyser id
+    required: true
+
+  - name: THOTH_BUILD_LOG_DOC_ID
+    description: Document id of Build log present in ceph.
+    displayName: Build Log Document ID
+    required: true
+
+  - name: THOTH_REPORT_OUTPUT
+    description: Remote where results should be send to.
+    displayName: ImageStream Tag
+    required: true
+
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ${THOTH_BUILD_ANALYSER_JOB_ID}
+      labels:
+        app: thoth
+        component: build-analyse
+        mark: cleanup
+        task: build-analyser
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: thoth
+            component: build-analyse
+            mark: cleanup
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          containers:
+            - name: build-analyse
+              image: "${IMAGE_STREAM_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/build-analyser:${IMAGE_STREAM_TAG}"
+              env:
+                - name: THOTH_BUILD_LOG_DOC_ID
+                  value: "${THOTH_BUILD_LOG_DOC_ID}"
+                - name: THOTH_BUILD_ANALYSER_LOG_PATH
+                  value: "${THOTH_BUILD_ANALYSER_LOG_PATH}"
+                - name: THOTH_BUILD_ANALYSER_OUTPUT_FORMAT
+                  value: "${THOTH_BUILD_ANALYSER_OUTPUT_FORMAT}"
+                - name: THOTH_REPORT_OUTPUT
+                  value: "${THOTH_REPORT_OUTPUT}"
+                - name: THOTH_BUILD_ANALYSER_SUBCOMMAND
+                  value: "analyse"
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      key: storage-bucket-name
+                      name: thoth
+                - name: THOTH_S3_ENDPOINT_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-host
+                      name: thoth
+                - name: THOTH_CEPH_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-bucket-name
+                      name: thoth
+                - name: THOTH_CEPH_BUCKET_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-bucket-prefix
+                      name: thoth
+                - name: THOTH_CEPH_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: ceph-key-id
+                - name: THOTH_CEPH_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: ceph-secret-key
+                - name: PROMETHEUS_PUSHGATEWAY_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: prometheus-pushgateway-host
+                      name: thoth
+                - name: PROMETHEUS_PUSHGATEWAY_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: prometheus-pushgateway-port
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: sentry-dsn
+              resources:
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+                requests:
+                  memory: "512Mi"
+                  cpu: "500m"

--- a/openshift/job-build-dependencies-template.yaml
+++ b/openshift/job-build-dependencies-template.yaml
@@ -1,0 +1,151 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: build-dependencies
+  annotations:
+    description: "Thoth: Build Log Analysis Dependencies"
+    openshift.io/display-name: "Thoth: Build Log Analysis Dependencies"
+    version: 0.1.0
+    tags: thoth,ai-stacks,build-analyser
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to run recommendation logic of Thoth to OpenShift.
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+  labels:
+    app: thoth
+    template: build-dependencies
+    component: build-dependencies
+
+parameters:
+  - name: IMAGE_STREAM_REGISTRY
+    description: Registry where the ImageStream is present.
+    displayName: ImageStream Registry
+    required: true
+    value: "docker-registry.default.svc:5000"
+
+  - name: IMAGE_STREAM_TAG
+    description: Tag of the ImageStream to be used.
+    displayName: ImageStream Tag
+    required: true
+    value: "latest"
+
+  - name: THOTH_BUILD_ANALYSER_LOG_PATH
+    description: Path for the build log read/write.
+    displayName: Log Path
+    required: false
+    value: "/opt/app-root/src/build.log"
+
+  - name: THOTH_BUILD_ANALYSER_OUTPUT_FORMAT
+    description: Required Output format.
+    displayName: ImageStream Tag
+    required: false
+    value: "json"
+
+  - name: IMAGE_STREAM_NAMESPACE
+    description: Project/Namespace to be used for deployment.
+    displayName: ImageStream Project
+    required: true
+
+  - name: THOTH_BUILD_ANALYSER_JOB_ID
+    description: A unique dentifier of build-analyser job.
+    displayName: Build Analyser id
+    required: true
+
+  - name: THOTH_BUILD_LOG_DOC_ID
+    description: Document id of Build log present in ceph.
+    displayName: Build Log Document ID
+    required: true
+
+  - name: THOTH_REPORT_OUTPUT
+    description: Remote where results should be send to.
+    displayName: ImageStream Tag
+    required: true
+
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ${THOTH_BUILD_ANALYSER_JOB_ID}
+      labels:
+        app: thoth
+        component: build-dependencies
+        operator: graph-sync
+        task: build-analyser
+        mark: cleanup
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: thoth
+            component: build-dependencies
+            mark: cleanup
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          containers:
+            - name: build-dependencies
+              image: "${IMAGE_STREAM_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/build-analyser:${IMAGE_STREAM_TAG}"
+              env:
+                - name: THOTH_BUILD_LOG_DOC_ID
+                  value: "${THOTH_BUILD_LOG_DOC_ID}"
+                - name: THOTH_BUILD_ANALYSER_LOG_PATH
+                  value: "${THOTH_BUILD_ANALYSER_LOG_PATH}"
+                - name: THOTH_BUILD_ANALYSER_OUTPUT_FORMAT
+                  value: "${THOTH_BUILD_ANALYSER_OUTPUT_FORMAT}"
+                - name: THOTH_REPORT_OUTPUT
+                  value: "${THOTH_REPORT_OUTPUT}"
+                - name: THOTH_BUILD_ANALYSER_SUBCOMMAND
+                  value: "dependencies"
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      key: storage-bucket-name
+                      name: thoth
+                - name: THOTH_S3_ENDPOINT_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-host
+                      name: thoth
+                - name: THOTH_CEPH_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-bucket-name
+                      name: thoth
+                - name: THOTH_CEPH_BUCKET_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-bucket-prefix
+                      name: thoth
+                - name: THOTH_CEPH_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: ceph-key-id
+                - name: THOTH_CEPH_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: ceph-secret-key
+                - name: PROMETHEUS_PUSHGATEWAY_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: prometheus-pushgateway-host
+                      name: thoth
+                - name: PROMETHEUS_PUSHGATEWAY_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: prometheus-pushgateway-port
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: sentry-dsn
+              resources:
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+                requests:
+                  memory: "512Mi"
+                  cpu: "500m"

--- a/openshift/job-build-report-template.yaml
+++ b/openshift/job-build-report-template.yaml
@@ -1,0 +1,157 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: build-report
+  annotations:
+    description: "Thoth: Build Log Analysis Report"
+    openshift.io/display-name: "Thoth: Build Log Analysis Report"
+    version: 0.1.0
+    tags: thoth,ai-stacks,build-report
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to run recommendation logic of Thoth to OpenShift.
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+  labels:
+    app: thoth
+    template: build-report
+    component: build-report
+
+parameters:
+  - name: IMAGE_STREAM_REGISTRY
+    description: Registry where the ImageStream is present.
+    displayName: ImageStream Registry
+    required: true
+    value: "docker-registry.default.svc:5000"
+
+  - name: IMAGE_STREAM_TAG
+    description: Tag of the ImageStream to be used.
+    displayName: ImageStream Tag
+    required: true
+    value: "latest"
+
+  - name: THOTH_BUILD_ANALYSER_LOG_PATH
+    description: Path for the build log read/write.
+    displayName: Log Path
+    required: false
+    value: "/opt/app-root/src/build.log"
+
+  - name: IMAGE_STREAM_NAMESPACE
+    description: Project/Namespace to be used for deployment.
+    displayName: ImageStream Project
+    required: true
+
+  - name: THOTH_BUILD_ANALYSER_JOB_ID
+    description: A unique dentifier of build-analyser job.
+    displayName: Build Analyser id
+    required: true
+
+  - name: THOTH_BUILD_LOG_DOC_ID
+    description: Document id of Build log present in ceph.
+    displayName: Build Log Document ID
+    required: true
+
+  - name: THOTH_REPORT_OUTPUT
+    description: Remote where results should be send to.
+    displayName: ImageStream Tag
+    required: true
+
+  - name: THOTH_BUILD_ANALYSER_HANDLER
+    description: Handler to parse log dependencies(pip, pipenv).
+    displayName: Build analyser handler
+    required: false
+
+  - name: THOTH_BUILD_ANALYSER_LIMIT
+    description: Limit number of candidates.
+    displayName: Build analyser limit
+    required: false
+
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ${THOTH_BUILD_ANALYSER_JOB_ID}
+      labels:
+        app: thoth
+        component: build-report
+        operator: graph-sync
+        task: build-analyser
+        mark: cleanup
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: thoth
+            component: build-report
+            mark: cleanup
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          containers:
+            - name: build-report
+              image: "${IMAGE_STREAM_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/build-analyser:${IMAGE_STREAM_TAG}"
+              env:
+                - name: THOTH_BUILD_LOG_DOC_ID
+                  value: "${THOTH_BUILD_LOG_DOC_ID}"
+                - name: THOTH_BUILD_ANALYSER_LOG_PATH
+                  value: "${THOTH_BUILD_ANALYSER_LOG_PATH}"
+                - name: THOTH_REPORT_OUTPUT
+                  value: "${THOTH_REPORT_OUTPUT}"
+                - name: THOTH_BUILD_ANALYSER_HANDLER
+                  value: "${THOTH_BUILD_ANALYSER_HANDLER}"
+                - name: THOTH_BUILD_ANALYSER_LIMIT
+                  value: "${THOTH_BUILD_ANALYSER_LIMIT}"
+                - name: THOTH_BUILD_ANALYSER_SUBCOMMAND
+                  value: "report"
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      key: storage-bucket-name
+                      name: thoth
+                - name: THOTH_S3_ENDPOINT_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-host
+                      name: thoth
+                - name: THOTH_CEPH_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-bucket-name
+                      name: thoth
+                - name: THOTH_CEPH_BUCKET_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ceph-bucket-prefix
+                      name: thoth
+                - name: THOTH_CEPH_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: ceph-key-id
+                - name: THOTH_CEPH_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: ceph-secret-key
+                - name: PROMETHEUS_PUSHGATEWAY_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: prometheus-pushgateway-host
+                      name: thoth
+                - name: PROMETHEUS_PUSHGATEWAY_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: prometheus-pushgateway-port
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: sentry-dsn
+              resources:
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+                requests:
+                  memory: "512Mi"
+                  cpu: "500m"

--- a/thoth/build_analysers/cli.py
+++ b/thoth/build_analysers/cli.py
@@ -82,10 +82,14 @@ def cli():
 
 
 @cli.command()
-@click.argument("log", type=click.Path(exists=True))
-@click.option("--limit", "-n", help="Limit number of candidates.", type=int)
+@click.argument("log", envvar="THOTH_BUILD_ANALYSER_LOG_PATH", type=click.Path(exists=True))
+@click.option("--limit", "-n", envvar="THOTH_BUILD_ANALYSER_LIMIT", help="Limit number of candidates.", type=int)
 @click.option(
-    "--handler", help="Handler to parse log dependencies.", type=click.Choice(choices=["pip3", "pipenv"]), default=None
+    "--handler",
+    help="Handler to parse log dependencies.",
+    envvar="THOTH_BUILD_ANALYSER_HANDLER",
+    type=click.Choice(choices=["pip3", "pipenv"]),
+    default=None,
 )
 @click.option("--colorize/--no-colorize", default=True)
 @click.option("--pretty", "-p", is_flag=True, default=False)
@@ -109,11 +113,12 @@ def report(
 
 
 @cli.command()
-@click.argument("log", type=click.Path(exists=True))
+@click.argument("log", envvar="THOTH_BUILD_ANALYSER_LOG_PATH", type=click.Path(exists=True))
 @click.option(
     "--output",
     "-o",
     help="Output format.",
+    envvar="THOTH_BUILD_ANALYSER_OUTPUT_FORMAT",
     type=click.Choice(choices=["dict", "html", "json", "plain", "records"]),
     default="plain",
 )
@@ -130,11 +135,12 @@ def analyse(log: Union[str, Path], output: str = "plain", pretty: bool = False) 
 
 
 @cli.command()
-@click.argument("log", type=click.Path(exists=True))
+@click.argument("log", envvar="THOTH_BUILD_ANALYSER_LOG_PATH", type=click.Path(exists=True))
 @click.option(
     "--output",
     "-o",
     help="Output format.",
+    envvar="THOTH_BUILD_ANALYSER_OUTPUT_FORMAT",
     type=click.Choice(choices=["dict", "html", "json", "plain", "records"]),
     default="plain",
 )


### PR DESCRIPTION
- Added required environment variable for thoth-common and openshift to interact with build-analyser.
- OpenShift Templates for the build analysers is added.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>