### PR TITLE
compatible with graph-sync-scheduler

### DIFF
--- a/openshift/job-build-analyze-template.yaml
+++ b/openshift/job-build-analyze-template.yaml
@@ -77,8 +77,9 @@ objects:
       labels:
         app: thoth
         component: build-analyze
+        operator: graph-sync
         mark: cleanup
-        task: build-analyzer
+        task: build-analyze
     spec:
       backoffLimit: 0
       template:

--- a/openshift/job-build-dependencies-template.yaml
+++ b/openshift/job-build-dependencies-template.yaml
@@ -78,7 +78,7 @@ objects:
         app: thoth
         component: build-dependencies
         operator: graph-sync
-        task: build-analyzer
+        task: build-dependencies
         mark: cleanup
     spec:
       backoffLimit: 0

--- a/openshift/job-build-report-template.yaml
+++ b/openshift/job-build-report-template.yaml
@@ -82,7 +82,7 @@ objects:
         app: thoth
         component: build-report
         operator: graph-sync
-        task: build-analyzer
+        task: build-report
         mark: cleanup
     spec:
       backoffLimit: 0


### PR DESCRIPTION
The task is used to differentiate between different sync operations, for exclusivity added task to each job respectively. 
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>